### PR TITLE
Revert "Update ghcr.io/linuxserver/heimdall Docker tag to v2021"

### DIFF
--- a/heimdall/compose.yaml
+++ b/heimdall/compose.yaml
@@ -2,7 +2,7 @@
 version: "2.1"
 services:
   heimdall:
-    image: ghcr.io/linuxserver/heimdall:2021.11.28
+    image: ghcr.io/linuxserver/heimdall:2.6.3
     container_name: heimdall
     environment:
       - PUID=1000


### PR DESCRIPTION
Reverts jw4gg/Homelab_Containers#13

this is definitely not a real version, broke it for sure