### PR TITLE
Separate Trivy image scanning into dedicated workflow

### DIFF
--- a/.github/workflows/trivy-image-scan.yml
+++ b/.github/workflows/trivy-image-scan.yml
@@ -1,0 +1,68 @@
+name: Trivy Image CVE Scan
+
+on:
+  schedule:
+    - cron: "0 10 * * 1" # Every Monday at 10am UTC
+  workflow_dispatch:
+
+jobs:
+  image-scan:
+    name: Image CVE Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract images from compose files
+        run: |
+          python3 - <<'EOF'
+          import yaml, glob
+          images = set()
+          for f in glob.glob("**/compose.yaml", recursive=True):
+              with open(f) as fh:
+                  d = yaml.safe_load(fh) or {}
+              for svc in (d.get("services") or {}).values():
+                  if svc and "image" in svc:
+                      images.add(svc["image"])
+          with open("images.txt", "w") as out:
+              out.write("\n".join(sorted(images)) + "\n")
+          print(f"Found {len(images)} unique images.")
+          EOF
+          cat images.txt
+
+      - name: Scan images with Trivy
+        run: |
+          mkdir -p trivy-results
+          {
+            echo "# Image CVE Scan Results"
+            echo ""
+            echo "Severity filter: HIGH, CRITICAL"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          while IFS= read -r image; do
+            [ -z "$image" ] && continue
+            echo "Scanning: $image"
+            safe=$(echo "$image" | tr '/: ' '___')
+
+            docker run --rm \
+              aquasec/trivy:latest image \
+              --severity HIGH,CRITICAL \
+              --no-progress \
+              --format table \
+              "$image" > "trivy-results/${safe}.txt" 2>&1 || true
+
+            {
+              echo "## \`$image\`"
+              echo '```'
+              head -60 "trivy-results/${safe}.txt"
+              echo '```'
+              echo ""
+            } >> "$GITHUB_STEP_SUMMARY"
+          done < images.txt
+
+      - name: Upload scan results
+        uses: actions/upload-artifact@v7
+        with:
+          name: trivy-image-results
+          path: trivy-results/
+          retention-days: 30

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -3,8 +3,6 @@ name: Trivy Security Scan
 on:
   push:
   pull_request:
-  schedule:
-    - cron: "0 10 * * 1" # Every Monday at 10am UTC
 
 jobs:
   config-scan:
@@ -40,66 +38,3 @@ jobs:
           scan-ref: .
           format: table
           severity: HIGH,CRITICAL
-
-  image-scan:
-    name: Image CVE Scan
-    runs-on: ubuntu-latest
-    # Only run on schedule or manual trigger to avoid slowing down every push
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Extract images from compose files
-        run: |
-          python3 - <<'EOF'
-          import yaml, glob
-          images = set()
-          for f in glob.glob("**/compose.yaml", recursive=True):
-              with open(f) as fh:
-                  d = yaml.safe_load(fh) or {}
-              for svc in (d.get("services") or {}).values():
-                  if svc and "image" in svc:
-                      images.add(svc["image"])
-          with open("images.txt", "w") as out:
-              out.write("\n".join(sorted(images)) + "\n")
-          print(f"Found {len(images)} unique images.")
-          EOF
-          cat images.txt
-
-      - name: Scan images with Trivy
-        run: |
-          mkdir -p trivy-results
-          {
-            echo "# Image CVE Scan Results"
-            echo ""
-            echo "Severity filter: HIGH, CRITICAL"
-            echo ""
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          while IFS= read -r image; do
-            [ -z "$image" ] && continue
-            echo "Scanning: $image"
-            safe=$(echo "$image" | tr '/: ' '___')
-
-            docker run --rm \
-              aquasec/trivy:latest image \
-              --severity HIGH,CRITICAL \
-              --no-progress \
-              --format table \
-              "$image" > "trivy-results/${safe}.txt" 2>&1 || true
-
-            {
-              echo "## \`$image\`"
-              echo '```'
-              head -60 "trivy-results/${safe}.txt"
-              echo '```'
-              echo ""
-            } >> "$GITHUB_STEP_SUMMARY"
-          done < images.txt
-
-      - name: Upload scan results
-        uses: actions/upload-artifact@v7
-        with:
-          name: trivy-image-results
-          path: trivy-results/
-          retention-days: 30


### PR DESCRIPTION
## Summary
Refactored the Trivy security scanning workflows by extracting the image CVE scanning job into a separate, dedicated workflow file. This improves workflow organization and allows for independent scheduling and execution of image scans.

## Key Changes
- Created new `.github/workflows/trivy-image-scan.yml` workflow with:
  - Scheduled execution every Monday at 10am UTC
  - Manual trigger support via `workflow_dispatch`
  - Image extraction from compose files
  - Trivy CVE scanning with HIGH and CRITICAL severity filtering
  - Artifact upload for scan results (30-day retention)

- Modified `.github/workflows/trivy-scan.yml`:
  - Removed the `image-scan` job and its associated schedule trigger
  - Removed the schedule cron configuration (moved to dedicated workflow)
  - Kept the `config-scan` job for repository configuration scanning on push/PR

## Implementation Details
- Image scanning now runs independently on a weekly schedule, avoiding performance impact on every push/PR
- The dedicated workflow maintains all original functionality including Docker-based Trivy scanning, result formatting, and artifact storage
- Configuration scanning continues to run on every push and pull request as before

https://claude.ai/code/session_01PX7ybRB96goHJumAk6jZLx